### PR TITLE
Make exit logger a function

### DIFF
--- a/laaf.ml
+++ b/laaf.ml
@@ -9,7 +9,7 @@ let laaf_dispatch app_t () =
   Logger.square_func_executed cb_ans;
   let sq2_ans = Math.sq 11 in 
   Logger.square_func_executed sq2_ans;
-  Logger.process_terminated (* ph: process exits before this? *)
+  Logger.process_terminated ()
 
 let application_term =
   Arg.(value

--- a/logger.ml
+++ b/logger.ml
@@ -2,7 +2,7 @@
 let process_started name =
   Logs.info (fun m -> m "Started process %s" name)
 
-let process_terminated =
+let process_terminated () =
   Logs.info (fun m -> m "Exiting process")
 
 let square_func_executed res =


### PR DESCRIPTION
This fixes the process exit log message by making `process_terminated` into a function.

The reason nothing was being printed previously, even when debug logging was enabled, is that `process_terminated` was a vanilla, top level module value rather than a function.  So the `Logs.debug ...` call was made _immediately_ at program start, before any command line processing or other setup was done.  `Logs` does not have a reporter configured by default so the message was created and dropped into the ether.